### PR TITLE
Adds runnables and tasks for easier compilation

### DIFF
--- a/languages/typst/runnables.scm
+++ b/languages/typst/runnables.scm
@@ -1,8 +1,0 @@
-; tag the whole document
-
-(
-
-	(source_file) @run @typst-compile
-	(#set! tag typst-compile)
-
-)

--- a/languages/typst/runnables.scm
+++ b/languages/typst/runnables.scm
@@ -1,0 +1,8 @@
+; tag the whole document
+
+(
+
+	(source_file) @run @typst-compile
+	(#set! tag typst-compile)
+
+)

--- a/languages/typst/tasks.json
+++ b/languages/typst/tasks.json
@@ -3,11 +3,7 @@
 		"label": "Typst: export file",
 		"command": "typst",
 		"args": ["compile", "\"$ZED_FILE\""],
-		"reveal": "never",
-		"hide": "never",
-		"tags": ["typst-compile"]
 	},
-
 	{
 		"label": "Typst: watch file",
 		"command": "typst",

--- a/languages/typst/tasks.json
+++ b/languages/typst/tasks.json
@@ -1,0 +1,18 @@
+[
+	{
+		"label": "Typst: export file",
+		"command": "typst",
+		"args": ["compile", "\"$ZED_FILE\""],
+		"reveal": "never",
+		"hide": "never",
+		"tags": ["typst-compile"]
+	},
+
+	{
+		"label": "Typst: watch file",
+		"command": "typst",
+		"args": ["watch", "\"$ZED_FILE\""],
+		"reveal": "never",
+		"hide": "always"
+	}
+]


### PR DESCRIPTION
Now there is a small "run" button at the top of the document so that when it is clicked, the file is automatically compiled to PDF (see image below)

![image](https://github.com/user-attachments/assets/a80e7ecc-33b5-42f1-84f9-057c6a248aa5)
