### PR TITLE
Fix README.md usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ project-specific config),
   "tinymist": {
     "initialization_options": {
       "exportPdf": "onSave",
-      "outputPath": "$root/$name",
-      "typstExtraArgs": ["--", "main.typ"]
+      "outputPath": "$root/$name"
     }
   }
 }


### PR DESCRIPTION
This isn't needed for compilation on save to work.
Also fixes lsp crash

```sh
Language server error: tinymist

failed to parse typstExtraArgs: error: unexpected argument '--' found

Usage: typst-cli [OPTIONS] [INPUT]

For more information, try '--help'.
```