### PR TITLE
Improve highlight, outline, documentation, and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ To register the LSP and enable certain features (such as compile on save), add t
   "tinymist": {
 		"initialization_options": {
 				// Enable background preview
+				// Server will be running on 127.0.0.1:23635
 				"preview": {
 					"background": {
 						"enabled": true,

--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 
 ## Usage
 
-To register the LSP and enable certain features (such as compile on save), add the following your `settings.json` (or `.zed/settings.json` in the project root for project-specific config),
+To register the LSP and enable certain features (such as compile on save), add the following to your local (resp. server) configuration file (`~/.zed/settings.json`):
 
 ```jsonc
 // In settings.json
-"lsp": {
-  "tinymist": {
-		"initialization_options": {
+{
+	// ...
+	"lsp": {
+		"tinymist": {
+			"initialization_options": {
 				// Enable background preview
 				// Server will be running on 127.0.0.1:23635
 				"preview": {
@@ -18,21 +20,22 @@ To register the LSP and enable certain features (such as compile on save), add t
 				},
 			},
 
-    "settings": {
-   		// Compile on save
-     	// This will compile a PDF for the `main.typ` file in the project root.
-      "exportPdf": "onSave",
-      "outputPath": "$root/$name"
-      
-      // Enable formatter
-      "formatterMode": "typstyle",
-    }
-  }
+			"settings": {
+				// Compile on save
+				// This will compile a PDF for the `main.typ` file in the project root.
+				"exportPdf": "onSave",
+				"outputPath": "$root/$name"
+
+				// Enable formatter
+				"formatterMode": "typstyle",
+	    }
+	  }
+	}
+	// ...
 }
 ```
 
-
-To see all available options refer to [the tinymist documentation](https://github.com/Myriad-Dreamin/tinymist/blob/main/editors/neovim/Configuration.md). 
+To see all available options refer to [the tinymist documentation](https://github.com/Myriad-Dreamin/tinymist/blob/main/editors/neovim/Configuration.md).
 Beware that the configuration options displayed there apply to **NeoVim**, not Zed, so some might be incorrect or misleading
 
 ## Components

--- a/README.md
+++ b/README.md
@@ -1,26 +1,40 @@
 # Typst Extension for Zed
 
 ## Usage
-To register the LSP and enable certain features such as compile on save, add the
-following your `settings.json` (or `.zed/settings.json` in the project root for
-project-specific config),
 
-```json
+To register the LSP and enable certain features (such as compile on save), add the following your `settings.json` (or `.zed/settings.json` in the project root for project-specific config),
+
+```jsonc
+// In settings.json
 "lsp": {
   "tinymist": {
+		"initialization_options": {
+				// Enable background preview
+				"preview": {
+					"background": {
+						"enabled": true,
+					},
+				},
+			},
+
     "settings": {
+   		// Compile on save
+     	// This will compile a PDF for the `main.typ` file in the project root.
       "exportPdf": "onSave",
       "outputPath": "$root/$name"
+      
+      // Enable formatter
+      "formatterMode": "typstyle",
     }
   }
 }
 ```
 
-This will compile a PDF for the `main.typ` file in the project root.
 
-To see all available options refer to [the tinymist documentation](https://github.com/Myriad-Dreamin/tinymist/blob/main/editors/neovim/Configuration.md).
+To see all available options refer to [the tinymist documentation](https://github.com/Myriad-Dreamin/tinymist/blob/main/editors/neovim/Configuration.md). 
 Beware that the configuration options displayed there apply to **NeoVim**, not Zed, so some might be incorrect or misleading
 
 ## Components
+
 - Tree Sitter: [tree-sitter-typst](https://github.com/uben0/tree-sitter-typst/)
 - Language Server: [tinymist](https://github.com/Myriad-Dreamin/tinymist/)

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ To register the LSP and enable certain features (such as compile on save), add t
 
 	"languages": {
 		"Typst": {
-			// Enable soft wrap
-			"soft_wrap": "editor_width",
+			// Disable soft wrap
+			"soft_wrap": "none",
 		},
 	},
 }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ To register the LSP and enable certain features (such as compile on save), add t
 ```jsonc
 // In settings.json
 {
-	// ...
 	"lsp": {
 		"tinymist": {
 			"initialization_options": {
@@ -28,10 +27,16 @@ To register the LSP and enable certain features (such as compile on save), add t
 
 				// Enable formatter
 				"formatterMode": "typstyle",
-	    }
-	  }
-	}
-	// ...
+			}
+		}
+	},
+
+	"languages": {
+		"Typst": {
+			// Enable soft wrap
+			"soft_wrap": "editor_width",
+		},
+	},
 }
 ```
 

--- a/languages/typst/brackets.scm
+++ b/languages/typst/brackets.scm
@@ -8,7 +8,21 @@
   "}" @close)
 
 ("\"" @open
-  "\"" @close)
+  "\"" @close
+  (#set! rainbow.exclude))
+
+("`" @open
+  "`" @close
+  (#set! rainbow.exclude))
+
+("`" @open
+  "`" @close
+  (#set! rainbow.exclude))
+
+("```" @open
+  "```" @close
+  (#set! rainbow.exclude))
 
 ("$" @open
-  "$" @close)
+  "$" @close
+  (#set! rainbow.exclude))

--- a/languages/typst/brackets.scm
+++ b/languages/typst/brackets.scm
@@ -15,10 +15,6 @@
   "`" @close
   (#set! rainbow.exclude))
 
-("`" @open
-  "`" @close
-  (#set! rainbow.exclude))
-
 ("```" @open
   "```" @close
   (#set! rainbow.exclude))

--- a/languages/typst/config.toml
+++ b/languages/typst/config.toml
@@ -2,20 +2,18 @@ name = "Typst"
 grammar = "typst"
 path_suffixes = ["typ", "typst"]
 line_comments = ["// "]
+documentation_comment = { start = "/*", prefix = "* ", end = "*/", tab_size = 1 }
 tab_size = 2
 brackets = [
+	{ start = "/*", end = " */", close = true, newline = true, not_in = ["string", "comment"] },
     { start = "(", end = ")", close = true, newline = true },
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },
     { start = "$", end = "$", close = true, newline = true },
-    { start = "\"", end = "\"", close = true, newline = false, not_in = [
-        "string",
-    ] },
-    { start = "*", end = "*", close = false, newline = false, surround = true, not_in = [
-        "math"
-    ] },
-    { start = "_", end = "_", close = false, newline = false, surround = true, not_in = [
-        "math"
-    ]  },
-    { start = "`", end = "`", close = false, newline = false, surround = true },
+    { start = "`", end = "`", close = true, newline = false, surround = true },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
+    { start = "*", end = "*", close = true, newline = false, surround = true, not_in = ["string", "math"] },
+    { start = "_", end = "_", close = true, newline = false, surround = true, not_in = ["string", "math"] },
 ]
+unordered_list = ["- ", "+ "]
+ordered_list = [{ pattern = "(\\d+)\\. ", format = "{1}. " }]

--- a/languages/typst/config.toml
+++ b/languages/typst/config.toml
@@ -4,6 +4,7 @@ path_suffixes = ["typ", "typst"]
 line_comments = ["// "]
 documentation_comment = { start = "/*", prefix = "* ", end = "*/", tab_size = 1 }
 tab_size = 2
+soft_wrap = "editor_width"
 brackets = [
 	{ start = "/*", end = " */", close = true, newline = true, not_in = ["string", "comment"] },
     { start = "(", end = ")", close = true, newline = true },

--- a/languages/typst/highlights.scm
+++ b/languages/typst/highlights.scm
@@ -1,9 +1,8 @@
 ; Taken from https://github.com/uben0/tree-sitter-typst/blob/f457c77edffd4b93190794355ff5acf7acfb99c6/editors/helix/queries/highlights.scm#L4
 ; Improved by @Gaspartcho
-; CONTROL
-(let
-  "let" @keyword.storage.type)
 
+
+; CONTROL
 (branch
   [
     "if"
@@ -19,8 +18,21 @@
     "in"
   ] @keyword.control.repeat)
 
+(flow
+  [
+    "break"
+    "continue"
+  ] @keyword.control)
+
+(return
+  "return" @keyword.control)
+
+
+; DIRECTIVES
 (import
   "import" @keyword.control.import)
+
+(wildcard) @operator
 
 (as
   "as" @keyword.operator)
@@ -34,14 +46,9 @@
 (set
   "set" @keyword.control)
 
-(return
-  "return" @keyword.control)
+(let
+  "let" @keyword.storage.type)
 
-(flow
-  [
-    "break"
-    "continue"
-  ] @keyword.control)
 
 ; OPERATOR
 (in
@@ -90,70 +97,16 @@
     ">"
   ] @operator)
 
-(fraction
-  "/" @operator)
+(tagged
+  field: (ident) @variable.parameter)
 
-(fac
-  "!" @operator)
+(field
+  field: (_) @property
+)
 
-(attach
-  [
-    "^"
-    "_"
-  ] @operator)
-
-(wildcard) @operator
 
 ; VALUE
 (ident) @variable
-
-(raw_blck
-  "```" @punctuation.delimiter
-  (blob) @text.literal)
-
-(raw_blck
-  lang: (ident) @tag)
-
-(raw_span
-  "`" @punctuation.delimiter
-  (blob) @text.literal)
-
-(label) @tag
-
-(ref) @tag
-
-(number) @number
-
-(string) @string
-
-(content
-  [
-    "["
-    "]"
-  ] @operator)
-
-(bool) @boolean
-
-(none) @constant.builtin
-
-(auto) @constant.builtin
-
-; Functions
-(formula
-  (ident) @function.method)
-
-(attach
-  (ident) @function.method)
-
-(formula
-  (field
-    (ident) @function.method))
-
-(tagged
-  field: (ident) @tag)
-
-(field
-  field: (ident) @tag)
 
 (call
   item: (ident) @function)
@@ -161,6 +114,65 @@
 (call
   item: (field
     field: (ident) @function.method))
+
+; RAW
+(raw_blck
+  "```" @embedded
+  (blob) @text.literal)
+
+(raw_blck
+  lang: (ident) @embedded)
+
+(raw_span
+  "`" @punctuation.delimiter
+  (blob) @text.literal)
+
+
+; MATH
+[
+  (label)
+  (ref)
+] @label
+
+(number) @number
+
+(string) @string
+
+(bool) @boolean
+
+(none) @constant.builtin
+
+(auto) @constant.builtin
+
+(formula
+  (ident) @constant)
+
+(formula
+  (field
+    (ident) @constant
+  )
+)
+
+(attach
+  (ident) @constant)
+
+(attach
+  (field
+    (ident) @constant
+  )
+)
+
+(attach
+  [
+    "^"
+    "_"
+  ] @operator)
+
+(fraction
+  "/" @operator)
+
+(fac
+  "!" @operator)
 
 ; MARKUP
 (item
@@ -174,7 +186,7 @@
 
 (heading) @title
 
-(url) @tag
+(url) @link_uri
 
 (emph) @emphasis
 
@@ -182,28 +194,33 @@
 
 (symbol) @operator
 
-(shorthand) @constant.builtin
+(shorthand) @operator
 
 (quote) @markup.quote
 
-(align) @operator
-
-(linebreak) @constant.builtin
+(code
+	"#" @punctuation.special)
 
 (math
-  "$" @operator)
+  "$" @punctuation.special)
 
-"#" @operator
+[
+  (align)
+  (linebreak)
+] @punctuation.special
+
 
 "end" @operator
 
-(escape) @constant.character.escape
+(escape) @string.escape
 
 [
   "("
   ")"
   "{"
   "}"
+  "["
+  "]"
 ] @punctuation.bracket
 
 [

--- a/languages/typst/highlights.scm
+++ b/languages/typst/highlights.scm
@@ -93,14 +93,14 @@
     ">"
   ] @operator)
 
+; VALUE
+(ident) @variable
+
 (tagged
   field: (ident) @variable.parameter)
 
 (field
   field: (_) @property)
-
-; VALUE
-(ident) @variable
 
 (call
   item: (ident) @function)

--- a/languages/typst/highlights.scm
+++ b/languages/typst/highlights.scm
@@ -1,7 +1,5 @@
 ; Taken from https://github.com/uben0/tree-sitter-typst/blob/f457c77edffd4b93190794355ff5acf7acfb99c6/editors/helix/queries/highlights.scm#L4
 ; Improved by @Gaspartcho
-
-
 ; CONTROL
 (branch
   [
@@ -27,7 +25,6 @@
 (return
   "return" @keyword.control)
 
-
 ; DIRECTIVES
 (import
   "import" @keyword.control.import)
@@ -48,7 +45,6 @@
 
 (let
   "let" @keyword.storage.type)
-
 
 ; OPERATOR
 (in
@@ -101,9 +97,7 @@
   field: (ident) @variable.parameter)
 
 (field
-  field: (_) @property
-)
-
+  field: (_) @property)
 
 ; VALUE
 (ident) @variable
@@ -127,7 +121,6 @@
   "`" @punctuation.delimiter
   (blob) @text.literal)
 
-
 ; MATH
 [
   (label)
@@ -149,18 +142,14 @@
 
 (formula
   (field
-    (ident) @constant
-  )
-)
+    (ident) @constant))
 
 (attach
   (ident) @constant)
 
 (attach
   (field
-    (ident) @constant
-  )
-)
+    (ident) @constant))
 
 (attach
   [
@@ -199,7 +188,7 @@
 (quote) @markup.quote
 
 (code
-	"#" @punctuation.special)
+  "#" @punctuation.special)
 
 (math
   "$" @punctuation.special)
@@ -208,7 +197,6 @@
   (align)
   (linebreak)
 ] @punctuation.special
-
 
 "end" @operator
 

--- a/languages/typst/highlights.scm
+++ b/languages/typst/highlights.scm
@@ -111,11 +111,11 @@
 
 ; RAW
 (raw_blck
-  "```" @embedded
+  "```" @punctuation.delimiter @embedded
   (blob) @text.literal)
 
 (raw_blck
-  lang: (ident) @embedded)
+  lang: (ident) @tag @embedded)
 
 (raw_span
   "`" @punctuation.delimiter

--- a/languages/typst/highlights.scm
+++ b/languages/typst/highlights.scm
@@ -151,6 +151,9 @@
   (field
     (ident) @constant))
 
+(fraction
+  (ident) @constant)
+
 (attach
   [
     "^"

--- a/languages/typst/highlights.scm
+++ b/languages/typst/highlights.scm
@@ -125,7 +125,7 @@
 [
   (label)
   (ref)
-] @label
+] @tag @label
 
 (number) @number
 
@@ -178,7 +178,7 @@
 
 (heading) @title
 
-(url) @link_uri
+(url) @tag @link_uri
 
 (emph) @emphasis
 
@@ -186,7 +186,7 @@
 
 (symbol) @operator
 
-(shorthand) @operator
+(shorthand) @constant.builtin @operator
 
 (quote) @markup.quote
 

--- a/languages/typst/indents.scm
+++ b/languages/typst/indents.scm
@@ -13,3 +13,6 @@
 (_
   "$"
   "$" @end) @indent
+
+((comment) @indent
+  (#match? @indent "^/\\*"))

--- a/languages/typst/outline.scm
+++ b/languages/typst/outline.scm
@@ -1,10 +1,8 @@
-(heading
-  [
-    "="
-    "=="
-    "==="
-    "===="
-    "====="
-    "======"
-  ] @context
-  (text) @name) @item
+(section
+	(heading
+		.
+		_ @context
+		.
+		(_)+ @name
+	)
+) @item

--- a/languages/typst/outline.scm
+++ b/languages/typst/outline.scm
@@ -1,8 +1,6 @@
 (section
 	(heading
-		.
-		_ @context
-		.
-		(_)+ @name
+		. _ @context
+		. (text) @name
 	)
 ) @item

--- a/languages/typst/outline.scm
+++ b/languages/typst/outline.scm
@@ -1,6 +1,6 @@
 (section
-	(heading
-		. _ @context
-		. (text) @name
-	)
-) @item
+  (heading
+    .
+    _ @context
+    .
+    (text) @name)) @item

--- a/languages/typst/overrides.scm
+++ b/languages/typst/overrides.scm
@@ -1,3 +1,5 @@
 (string) @string
 
 (math) @math
+
+(comment) @comment.inclusive

--- a/languages/typst/tasks.json
+++ b/languages/typst/tasks.json
@@ -1,13 +1,20 @@
 [
 	{
-		"label": "Typst: export file",
+		"label": "Typst: Export File",
 		"command": "typst",
-		"args": ["compile", "\"$ZED_FILE\""],
+		"args": ["compile", "\"$ZED_FILE\""]
 	},
 	{
-		"label": "Typst: watch file",
+		"label": "Typst: Watch File",
 		"command": "typst",
 		"args": ["watch", "\"$ZED_FILE\""],
+		"reveal": "never",
+		"hide": "always"
+	},
+	{
+		"label": "Typst: Open Preview",
+		"command": "xdg-open",
+		"args": ["http://127.0.0.1:23635/"],
 		"reveal": "never",
 		"hide": "always"
 	}

--- a/languages/typst/tasks.json
+++ b/languages/typst/tasks.json
@@ -2,7 +2,8 @@
 	{
 		"label": "Typst: Export File",
 		"command": "typst",
-		"args": ["compile", "\"$ZED_FILE\""]
+		"args": ["compile", "\"$ZED_FILE\""],
+		"hide": "on_success"
 	},
 	{
 		"label": "Typst: Watch File",


### PR DESCRIPTION
Closes #33
This PR introduces a few improvements to this extension

### Improved preview

The sections are now nested in the Outline panel

<img width="538" height="598" alt="image" src="https://github.com/user-attachments/assets/8f398e9e-e62c-4304-81a1-96267cf6bf4e" />

### Improved highlighting

Made so that the different highlights matched more the ones on the online typst editor.

It would be nice to experiment a bit more with this configuration, and see if any bugs appear.

### LSP features: Preview & formatting

Added instructions in the project's README on how to enable formatting.

Added instructions on how to start [preview](https://myriad-dreamin.github.io/tinymist/feature/preview.html) feature in the background (since Zed cannot run LSP commands as of writing, this is the only way to use this feature).

Added a task to open the preview.